### PR TITLE
Resolve fetch() URL constants in data source scanner

### DIFF
--- a/src/server/__tests__/data-source-scanner.test.ts
+++ b/src/server/__tests__/data-source-scanner.test.ts
@@ -87,6 +87,35 @@ describe('scanDataSources — proxy-aware resolved_endpoint', () => {
     }
   })
 
+  it('resolves fetch() calls that pass a URL constant instead of a string literal', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'annotask-scan-'))
+    try {
+      await fsp.writeFile(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'root', dependencies: { 'vue-router': '4.0.0' },
+      }))
+      await fsp.mkdir(path.join(tmp, 'src', 'components'), { recursive: true })
+      await fsp.writeFile(path.join(tmp, 'src', 'components', 'ItemList.tsx'), `
+        const LIST_URL = '/api/items?include_relations=true&limit=1000';
+        const DETAIL_URL = 'http://localhost:4320/api/items/42';
+        export function ItemList() {
+          const controller = new AbortController();
+          fetch(LIST_URL, { signal: controller.signal });
+          fetch(DETAIL_URL);
+        }
+      `)
+      clearDataSourceCache()
+      const cat = await scanDataSources(tmp)
+      const listEntry = cat.project_entries.find(e => e.endpoint === '/api/items?include_relations=true&limit=1000')
+      const detailEntry = cat.project_entries.find(e => e.endpoint === 'http://localhost:4320/api/items/42')
+      expect(listEntry).toBeDefined()
+      expect(listEntry!.kind).toBe('fetch')
+      expect(detailEntry).toBeDefined()
+      expect(detailEntry!.kind).toBe('fetch')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
   it('leaves resolved_endpoint undefined when no vite.config is reachable', async () => {
     const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'annotask-scan-'))
     try {

--- a/src/server/data-source-scanner.ts
+++ b/src/server/data-source-scanner.ts
@@ -506,9 +506,20 @@ function detectEntries(file: string, content: string, acc: ProjectDataEntry[]): 
       baseUrls.set(bm[1], bm[2].replace(/\/+$/, ''))
     }
 
+    // Also collect URL/path string constants so `fetch(LIST_URL, …)` — where
+    // LIST_URL is declared earlier as `const LIST_URL = '/api/items?…'` —
+    // still produces a catalog entry. Without this, any fetch whose URL is
+    // bound to a named constant is silently dropped (issue #29).
+    const urlConstants = new Map<string, string>()
+    const urlConstRe = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+)?=\s*['"`]((?:https?:\/\/|\/)[^'"`]+)['"`]/g
+    let uc: RegExpExecArray | null
+    while ((uc = urlConstRe.exec(content)) !== null) {
+      urlConstants.set(uc[1], uc[2])
+    }
+
     const seenEndpoints = new Set<string>()
     const pushEndpoint = (args: string, index: number) => {
-      const endpoint = extractEndpointFromArgs(args, baseUrls)
+      const endpoint = extractEndpointFromArgs(args, baseUrls, urlConstants)
       if (!endpoint) return
       if (seenEndpoints.has(endpoint)) return
       seenEndpoints.add(endpoint)
@@ -650,12 +661,14 @@ function collectHintSymbols(content: string, afterIndex: number): string[] {
  *   • full URLs:           fetch('http://host/api/health')
  *   • template literals:   fetch(`${API_BASE}/api/health`)  ← resolves
  *                          when API_BASE is a known file-local const
+ *   • bare identifiers:    fetch(LIST_URL, …)               ← resolves
+ *                          when LIST_URL is a known file-local const
  *
  * Returns the most specific endpoint we can reconstruct (absolute URL when
  * possible, otherwise path). Absolute URLs preserve the host/port so the
  * shell can disambiguate two backends that expose the same path.
  */
-function extractEndpointFromArgs(args: string, baseUrls: Map<string, string>): string | null {
+function extractEndpointFromArgs(args: string, baseUrls: Map<string, string>, urlConstants?: Map<string, string>): string | null {
   // 1. Plain string literal containing a full URL.
   const fullUrlMatch = args.match(/['"](https?:\/\/[^\s'"]+)['"]/)
   if (fullUrlMatch) return fullUrlMatch[1]
@@ -672,7 +685,19 @@ function extractEndpointFromArgs(args: string, baseUrls: Map<string, string>): s
     if (/^\/(?:api|graphql|rpc|v\d)\//.test(suffix)) return suffix
   }
 
-  // 3. Legacy fallback — any string literal with an /api-ish path inside.
+  // 3. Bare identifier as the first positional arg: `fetch(LIST_URL, …)`.
+  //    Resolve against the file-local string-constant table built by the
+  //    caller. Only accepts declarations whose value is a URL or a `/…`
+  //    path so we don't misinterpret unrelated string consts.
+  if (urlConstants && urlConstants.size > 0) {
+    const idMatch = args.match(/^\s*([A-Za-z_$][\w$]*)\s*(?:[,)]|$)/)
+    if (idMatch) {
+      const resolved = urlConstants.get(idMatch[1])
+      if (resolved) return resolved
+    }
+  }
+
+  // 4. Legacy fallback — any string literal with an /api-ish path inside.
   const pathMatch = args.match(/['"`][^'"`]*?(\/(?:api|graphql|rpc|v\d)\/[\w\-/.{}:?=&]*)/)
   if (pathMatch) return pathMatch[1]
   return null


### PR DESCRIPTION
## Summary
- Fixes #29 — the data-source scanner now detects `fetch()` calls whose URL argument is a named constant rather than a string literal.
- Collects file-local `const/let/var NAME = '<url-or-path>'` declarations into a lookup table and resolves bare identifier first-arguments (e.g. `fetch(LIST_URL, { signal })` → `/api/items?…`) before the legacy `/api`-path fallback runs.
- Added a regression test covering both a relative-path constant (`/api/items?…`) and a full-URL constant (`http://localhost:4320/api/items/42`).

## Test plan
- [x] `pnpm vitest run src/server/__tests__/data-source-scanner.test.ts` — 9/9 pass
- [x] `pnpm vitest run` — 223/223 pass